### PR TITLE
Removing Artist selection

### DIFF
--- a/modules/Qnite/plugin/qnitebar.cpp
+++ b/modules/Qnite/plugin/qnitebar.cpp
@@ -71,7 +71,6 @@ bool QniteBar::select(const QList<QPoint>& path)
   return false;
 }
 
-// TODO: selection should be cleared when data change
 void QniteBar::clearSelection()
 {
   m_selectedIndex = -1;

--- a/modules/Qnite/plugin/qnitexyartist.cpp
+++ b/modules/Qnite/plugin/qnitexyartist.cpp
@@ -54,6 +54,9 @@ void QniteXYArtist::setXValues(const QList<qreal>& values)
     // TODO: transform the values here and cache
     emit xValuesChanged();
     update();
+
+    // clear the current selection after any changes on X values
+    clearSelection();
   }
 }
 
@@ -69,6 +72,9 @@ void QniteXYArtist::setYValues(const QList<qreal>& values)
     // TODO: transform the values here and cache
     emit yValuesChanged();
     update();
+
+    // clear the current selection after any changes on Y values
+    clearSelection();
   }
 }
 

--- a/modules/Qnite/plugin/tools/qniteselectiontool.cpp
+++ b/modules/Qnite/plugin/tools/qniteselectiontool.cpp
@@ -34,3 +34,8 @@ void QniteSelectionTool::clearSelection()
     }
   }
 }
+
+void QniteSelectionTool::reset()
+{
+  clearSelection();
+}

--- a/modules/Qnite/plugin/tools/qniteselectiontool.h
+++ b/modules/Qnite/plugin/tools/qniteselectiontool.h
@@ -11,6 +11,7 @@ class QniteSelectionTool: public QniteTool
 public:
   explicit QniteSelectionTool(QQuickItem* parent = 0);
   virtual ~QniteSelectionTool() {}
+  Q_INVOKABLE void reset();
 
 protected:
   void select();

--- a/tests/plugin/tst_qniteselectiontool/tst_qniteselectiontool.cpp
+++ b/tests/plugin/tst_qniteselectiontool/tst_qniteselectiontool.cpp
@@ -99,6 +99,21 @@ private slots:
     QCOMPARE(a3.selected(), false);
     QCOMPARE(a4.selected(), false);
   }
+
+  void testReset()
+  {
+    sel.fooSelect();
+    QCOMPARE(a1.selected(), true);
+    QCOMPARE(a2.selected(), true);
+    QCOMPARE(a3.selected(), true);
+    QCOMPARE(a4.selected(), true);
+
+    sel.reset();
+    QCOMPARE(a1.selected(), false);
+    QCOMPARE(a2.selected(), false);
+    QCOMPARE(a3.selected(), false);
+    QCOMPARE(a4.selected(), false);
+  }
 };
 
 QTEST_MAIN(TestQniteSelectionTool)


### PR DESCRIPTION
Artist selection could be removed in the following ways:
- when X or Y values are changed
- using a new `reset()` method, available for `QniteSelectionTool` class
