### PR TITLE
Reworked selection to use unique ids instead of indexes

### DIFF
--- a/examples/plots/qml/LinePlot.qml
+++ b/examples/plots/qml/LinePlot.qml
@@ -1,3 +1,4 @@
+import QtQuick.Controls 2.0
 import Qnite 1.0
 
 Figure {
@@ -6,11 +7,21 @@ Figure {
 
     tools: [
         ZoomTool {
+            id: zoom
             anchors.fill: parent
         }
     ]
 
-    Grid { }
+    Grid {
+        Button {
+            anchors.top: parent.top
+            anchors.right: parent.right
+
+            text: "Reset Zoom"
+
+            onClicked: zoom.reset()
+        }
+    }
     Line {
         xValues: [0.0001, 0.00013, 0.0003, 0.0004, 0.00052]
         yValues: [0, 0.3, 0.6, 0.3, 0.4, 0.6]

--- a/examples/plots/qml/ScatterPlot.qml
+++ b/examples/plots/qml/ScatterPlot.qml
@@ -1,3 +1,4 @@
+import QtQuick.Controls 2.0
 import QtQuick 2.6
 import Qnite 1.0
 
@@ -8,10 +9,23 @@ Figure {
     tools: [
         PathSelectionTool {
             anchors.fill: parent
+        },
+        ZoomTool {
+            id: zoom
+            anchors.fill: parent
         }
     ]
 
-    Grid { }
+    Grid {
+        Button {
+            anchors.top: parent.top
+            anchors.right: parent.right
+
+            text: "Reset Zoom"
+
+            onClicked: zoom.reset()
+        }
+    }
     Circle {
         id: circle
         selectable: true

--- a/src/items/qnitebar.cpp
+++ b/src/items/qnitebar.cpp
@@ -7,7 +7,8 @@
 #include <algorithm>
 
 QniteBar::QniteBar(QQuickItem *parent)
-    : QniteXYArtist(parent), m_fixedWidth{10}, m_selectedIndex{-1} {}
+    : QniteXYArtist(parent), m_fixedWidth{10}, m_selectedId{-1},
+      m_selectedIndex{-1} {}
 
 void QniteBar::setFixedWidth(qreal w) {
   if (m_fixedWidth != w) {
@@ -37,13 +38,16 @@ void QniteBar::setCategories(const QStringList &c) {
 bool QniteBar::select(QPoint p) {
   auto accepted = false;
 
-  if (xProcessed().size() < 1) {
-    m_selectedIndex = -1;
+  if (m_xMapped.size() < 1) {
+    m_selectedId = -1;
   } else {
-    auto upper =
-        std::upper_bound(xProcessed().begin(), xProcessed().end(), p.x());
-    auto i = static_cast<int>(std::distance(xProcessed().begin(), upper) - 1);
-    m_selectedIndex = std::max(0, i);
+    auto upper = std::upper_bound(m_xMapped.cbegin(), m_xMapped.cend(), p.x());
+    if (upper != m_xMapped.cbegin()) {
+      upper--;
+    }
+    m_selectedId = upper.key();
+    m_selectedIndex = static_cast<int>(std::distance(upper, m_xMapped.cend()));
+
     accepted = true;
   }
 
@@ -62,6 +66,7 @@ bool QniteBar::select(const QList<QPoint> &path) {
 }
 
 void QniteBar::clearSelection() {
+  m_selectedId = -1;
   m_selectedIndex = -1;
   emit selectedChanged();
   update();
@@ -71,39 +76,4 @@ QNanoQuickItemPainter *QniteBar::createItemPainter() const {
   return new QniteBarPainter;
 }
 
-bool QniteBar::isSelected() const { return m_selectedIndex >= 0; }
-
-// QSGNode* QniteBar::updatePaintNode(QSGNode* node, UpdatePaintNodeData*)
-//{
-// processData();
-
-// auto dataSize = xProcessed().size();
-// if (dataSize < 1)
-// return nullptr;
-
-// if (node == nullptr) {
-// node = new QSGNode;
-// m_barsNode = new QSGNode;
-// node->appendChildNode(m_barsNode);
-//}
-// updateBars();
-
-// return node;
-//}
-
-// void QniteBar::updateBars()
-//{
-// m_barsNode->removeAllChildNodes();
-
-// qreal baseline = axes()->axisY()->position();
-
-// auto dataSize = xProcessed().size();
-// for(int i = 0; i < dataSize; ++i) {
-// qreal cx = xProcessed().at(i);
-// qreal cy = yProcessed().at(i);
-
-// auto c = (i == m_selectedIndex) ? selectedPen()->fill() : pen()->fill();
-// m_barsNode->appendChildNode(new QniteBarNode(cx, cy, baseline, fixedWidth(),
-// c));
-//}
-//}
+bool QniteBar::isSelected() const { return m_selectedId >= 0; }

--- a/src/items/qnitebar.h
+++ b/src/items/qnitebar.h
@@ -27,6 +27,7 @@ public:
   void clearSelection() Q_DECL_OVERRIDE;
 
   int selectedIndex() const { return m_selectedIndex; }
+  int selectedId() const { return m_selectedId; }
 
   QNanoQuickItemPainter *createItemPainter() const Q_DECL_OVERRIDE;
 
@@ -39,6 +40,7 @@ protected:
 
 private:
   qreal m_fixedWidth;
+  int m_selectedId;
   int m_selectedIndex;
 
   QStringList m_categories;

--- a/src/items/qnitebarpainter.cpp
+++ b/src/items/qnitebarpainter.cpp
@@ -19,8 +19,8 @@ void QniteBarPainter::synchronize(QNanoQuickItem *item) {
 
     // TODO: here we could share painting data using a class
     // which is copied with all its members in a local instance.
-    m_xs = barItem->xProcessed();
-    m_ys = barItem->yProcessed();
+    m_xs = barItem->xMapped();
+    m_ys = barItem->yMapped();
 
     // make a local copy of the pen
     m_pen = barItem->pen()->data();
@@ -29,7 +29,7 @@ void QniteBarPainter::synchronize(QNanoQuickItem *item) {
 
     // bar specific properties
     m_fixedWidth = barItem->fixedWidth();
-    m_selectedIndex = barItem->selectedIndex();
+    m_selectedId = barItem->selectedId();
     // the baseline is the position of the y axis
     // this is needed to compute a the starting point of the bar
     m_baseline = barItem->axes()->axisY()->position();
@@ -50,16 +50,17 @@ void QniteBarPainter::paint(QNanoPainter *painter) {
   painter->setLineCap(m_pen.cap);
 
   // draw unselected points
-  for (auto i = 0; i < dataSize; ++i) {
+  auto ids = m_xs.keys();
+  for (auto id : ids) {
     // we do not draw selected index because we draw it later
     // with a different pen
-    if (i == m_selectedIndex) {
+    if (id == m_selectedId) {
       continue;
     }
-    drawBar(m_xs.at(i), m_ys.at(i));
+    drawBar(m_xs.value(id), m_ys.value(id));
   }
 
-  if (m_selectedIndex >= 0) {
+  if (m_selectedId >= 0) {
     // use the selectedPen
     painter->setStrokeStyle(QNanoColor::fromQColor(m_selectedPen.stroke));
     painter->setFillStyle(QNanoColor::fromQColor(m_selectedPen.fill));
@@ -67,7 +68,7 @@ void QniteBarPainter::paint(QNanoPainter *painter) {
     painter->setLineJoin(m_selectedPen.join);
     painter->setLineCap(m_selectedPen.cap);
 
-    drawBar(m_xs.at(m_selectedIndex), m_ys.at(m_selectedIndex));
+    drawBar(m_xs.value(m_selectedId), m_ys.value(m_selectedId));
   }
 }
 

--- a/src/items/qnitebarpainter.cpp
+++ b/src/items/qnitebarpainter.cpp
@@ -52,7 +52,7 @@ void QniteBarPainter::paint(QNanoPainter *painter) {
   // draw unselected points
   auto ids = m_xs.keys();
   for (auto id : ids) {
-    // we do not draw selected index because we draw it later
+    // we do not draw selected ids because we draw it later
     // with a different pen
     if (id == m_selectedId) {
       continue;
@@ -60,7 +60,8 @@ void QniteBarPainter::paint(QNanoPainter *painter) {
     drawBar(m_xs.value(id), m_ys.value(id));
   }
 
-  if (m_selectedId >= 0) {
+  // Draw selected items only they're currently visible
+  if (m_selectedId >= 0 && ids.contains(m_selectedId)) {
     // use the selectedPen
     painter->setStrokeStyle(QNanoColor::fromQColor(m_selectedPen.stroke));
     painter->setFillStyle(QNanoColor::fromQColor(m_selectedPen.fill));

--- a/src/items/qnitebarpainter.h
+++ b/src/items/qnitebarpainter.h
@@ -20,13 +20,13 @@ private:
   QnitePen::PenData m_selectedPen;
 
   // xy artist data
-  QList<qreal> m_xs;
-  QList<qreal> m_ys;
+  QMap<int, qreal> m_xs;
+  QMap<int, qreal> m_ys;
 
   // bar data
   qreal m_baseline;
   qreal m_fixedWidth;
-  int m_selectedIndex;
+  int m_selectedId;
 };
 
 #endif /* QNITEBARPAINTER_H */

--- a/src/items/qnitecircle.cpp
+++ b/src/items/qnitecircle.cpp
@@ -13,7 +13,7 @@ Q_LOGGING_CATEGORY(qnitecircle, "qnite.circle")
 constexpr auto SELECTION_TOLERANCE = 20;
 
 QniteCircle::QniteCircle(QQuickItem *parent)
-    : QniteXYArtist(parent), m_highlightedPoint{-1} {
+    : QniteXYArtist(parent), m_highlightedId{-1}, m_highlightedIndex{-1} {
   setFlag(ItemHasContents, true);
   setClipper(new QniteClipper(this));
 }
@@ -34,22 +34,22 @@ bool QniteCircle::select(const QList<QPoint> &path) {
 
   // create a polygon with the path so it is easier to check
   // if a point is in the path or not
-  auto polygonPath = QPolygon(QVector<QPoint>::fromList(path));
+  auto polygonPath = QPolygonF(QVector<QPoint>::fromList(path));
 
   // cycle through all the points and save those contained
   // in the polygon
-  m_selectedPoints.clear();
-  auto dataSize = xMapped().size();
-  for (auto i = 0; i < dataSize; ++i) {
-    QPoint cp(xMapped().at(i), yMapped().at(i));
+  m_selectedIds.clear();
+  auto ids = m_xMapped.keys();
+  for (auto id : ids) {
+    QPointF cp(m_xMapped.value(id), m_yMapped.value(id));
 
     if (polygonPath.containsPoint(cp, Qt::OddEvenFill)) {
-      m_selectedPoints.insert(i);
+      m_selectedIds << id;
     }
   }
 
   // no points have been selected
-  if (m_selectedPoints.isEmpty()) {
+  if (m_selectedIds.isEmpty()) {
     return false;
   }
 
@@ -61,26 +61,30 @@ bool QniteCircle::select(const QList<QPoint> &path) {
 bool QniteCircle::select(const QPoint p) {
   // these variables are needed to keep
   // track of the nearest point during the search
+  auto nearestId = -1;
   auto nearestIndex = -1;
   // we only evaluate points whose distance is below a
   // predefined tolerance
-  auto nearestDistance = SELECTION_TOLERANCE;
+  qreal nearestDistance = SELECTION_TOLERANCE;
 
-  auto dataSize = xMapped().size();
-  for (auto i = 0; i < dataSize; ++i) {
-    QPoint cp(xMapped().at(i), yMapped().at(i));
-    QPoint d = p - cp;
-
+  auto ids = m_xMapped.keys();
+  auto index = 0;
+  for (auto id : ids) {
+    QPointF cp(m_xMapped.value(id), m_yMapped.value(id));
+    QPointF d = p - cp;
     auto distance = d.manhattanLength();
     if (distance < nearestDistance) {
-      nearestIndex = i;
+      nearestId = id;
+      nearestIndex = index;
       nearestDistance = distance;
     }
+    index++;
   }
 
   // add the index to the selected points pool
-  if (nearestIndex >= 0) {
-    m_selectedPoints.insert(nearestIndex);
+  if (nearestId >= 0) {
+    m_selectedIds.insert(nearestId);
+    m_selectedIndexes.insert(nearestIndex);
     emit selectedChanged();
     update();
     return true;
@@ -90,20 +94,23 @@ bool QniteCircle::select(const QPoint p) {
 }
 
 void QniteCircle::clearSelection() {
-  m_selectedPoints.clear();
-  m_highlightedPoint = -1;
+  m_selectedIds.clear();
+  m_selectedIndexes.clear();
+  m_highlightedId = -1;
+  m_highlightedIndex = -1;
   emit selectedChanged();
   update();
 }
 
 void QniteCircle::select(QList<int> indexes) {
-  auto dataSize = xValues().size();
-
-  m_selectedPoints.clear();
+  m_selectedIds.clear();
+  m_selectedIndexes.clear();
   for (auto i : indexes) {
-    // we only select valid indexes
-    if (i >= 0 && i < dataSize) {
-      m_selectedPoints.insert(i);
+    if (i >= 0 && i < m_xValues.size()) {
+      auto it = m_xValues.constBegin();
+      it = it + i;
+      m_selectedIds << it.key();
+      m_selectedIndexes << i;
     }
   }
   // TODO: should emit selectedChanged???
@@ -111,11 +118,13 @@ void QniteCircle::select(QList<int> indexes) {
 }
 
 void QniteCircle::highlight(int index) {
-  auto dataSize = xValues().size();
+  m_selectedIds.clear();
 
-  // we only highlight a valid index
-  if (index >= 0 && index < dataSize) {
-    m_highlightedPoint = index;
+  if (index >= 0 && index < m_xValues.size()) {
+    auto it = m_xValues.constBegin();
+    it = it + index;
+    m_highlightedId = it.key();
+    m_highlightedIndex = index;
   }
 
   update();
@@ -124,39 +133,3 @@ void QniteCircle::highlight(int index) {
 QNanoQuickItemPainter *QniteCircle::createItemPainter() const {
   return new QniteCirclePainter;
 }
-
-// QSGNode* QniteCircle::updatePaintNode(QSGNode* node, UpdatePaintNodeData*)
-//{
-// if (!node) {
-// node = new QSGNode;
-//}
-
-//// TODO: processdata should be triggered only when data changes
-// processData();
-// int dataSize = xMapped().size();
-
-//// TODO: find a better approach. removing and creating all nodes is bad
-// node->removeAllChildNodes();
-
-//// we draw the unselected points first
-// for(int i = 0; i < dataSize; ++i) {
-// qreal cx = xMapped().at(i);
-// qreal cy = yMapped().at(i);
-
-//// choose the color based on the selection status
-// auto pointColor = m_selectedPoints.contains(i) ? selectionColor() : color();
-
-//// we add the nodes to render selected points at the end of the scene graph
-//// se that they are drawn above unselected points.
-// if (m_selectedPoints.contains(i)) {
-//// TODO: optimal number of segments should be  computed runtime
-// node->appendChildNode(new QniteCircleNode(cx, cy, m_radius, 32, pointColor));
-//} else {
-//// TODO: optimal number of segments should be  computed runtime
-// node->prependChildNode(new QniteCircleNode(cx, cy, m_radius, 32,
-// pointColor));
-//}
-//}
-
-// return node;
-//}

--- a/src/items/qnitecircle.cpp
+++ b/src/items/qnitecircle.cpp
@@ -119,8 +119,6 @@ void QniteCircle::select(QList<int> indexes) {
 }
 
 void QniteCircle::highlight(int index) {
-  m_selectedIds.clear();
-
   if (index >= 0 && index < m_xValues.size()) {
     auto it = m_xValues.constBegin();
     it = it + index;

--- a/src/items/qnitecircle.cpp
+++ b/src/items/qnitecircle.cpp
@@ -77,6 +77,7 @@ bool QniteCircle::select(const QPoint p) {
       nearestId = id;
       nearestIndex = index;
       nearestDistance = distance;
+      break;
     }
     index++;
   }

--- a/src/items/qnitecircle.h
+++ b/src/items/qnitecircle.h
@@ -9,11 +9,14 @@ class QniteCircle : public QniteXYArtist {
   Q_PROPERTY(int highlightedIndex READ highlightedIndex)
 
 public:
-  explicit QniteCircle(QQuickItem *parent = 0);
-  virtual ~QniteCircle();
+  explicit QniteCircle(QQuickItem *parent = nullptr);
+  virtual ~QniteCircle() Q_DECL_OVERRIDE;
 
-  QList<int> selectedIndexes() const { return m_selectedPoints.toList(); }
-  int highlightedIndex() const { return m_highlightedPoint; }
+  QList<int> selectedIndexes() const { return m_selectedIndexes.toList(); }
+  int highlightedIndex() const { return m_highlightedIndex; }
+
+  QList<int> selectedIds() const { return m_selectedIds.toList(); }
+  int highlightedId() const { return m_highlightedId; }
 
   bool select(const QList<QPoint> &) Q_DECL_OVERRIDE;
   bool select(const QPoint) Q_DECL_OVERRIDE;
@@ -25,8 +28,11 @@ public:
   QNanoQuickItemPainter *createItemPainter() const Q_DECL_OVERRIDE;
 
 private:
-  QSet<int> m_selectedPoints; //! here we store the indexes of selected points
-  int m_highlightedPoint;
+  QSet<int> m_selectedIds; //! here we store the ids of selected points
+  int m_highlightedId;
+
+  QSet<int> m_selectedIndexes;
+  int m_highlightedIndex;
 };
 
 #endif // QNITE_CIRCLE_H

--- a/src/items/qnitecirclepainter.cpp
+++ b/src/items/qnitecirclepainter.cpp
@@ -16,8 +16,8 @@ void QniteCirclePainter::synchronize(QNanoQuickItem *item) {
 
     // TODO: here we could share painting data using a class
     // which is copied with all its members in a local instance.
-    m_xs = circleItem->xProcessed();
-    m_ys = circleItem->yProcessed();
+    m_xs = circleItem->xMapped();
+    m_ys = circleItem->yMapped();
 
     // make a local copy of the pen
     m_pen = circleItem->pen()->data();
@@ -26,17 +26,17 @@ void QniteCirclePainter::synchronize(QNanoQuickItem *item) {
     m_selected = circleItem->selected();
 
     // circle specific properties
-    m_selectedPoints = circleItem->selectedIndexes();
-    m_highlightedPoint = circleItem->highlightedIndex();
+    m_selectedIds = circleItem->selectedIds();
+    m_highlightedId = circleItem->highlightedId();
   }
 }
 
 void QniteCirclePainter::paint(QNanoPainter *painter) {
   qCDebug(qnitecirclepainter) << "painting qnitecircle";
 
-  auto dataSize = m_xs.size();
-  if (dataSize < 1)
+  if (m_xs.size() < 1) {
     return;
+  }
 
   painter->setStrokeStyle(QNanoColor::fromQColor(m_pen.stroke));
   painter->setFillStyle(QNanoColor::fromQColor(m_pen.fill));
@@ -45,40 +45,41 @@ void QniteCirclePainter::paint(QNanoPainter *painter) {
   painter->setLineCap(m_pen.cap);
 
   // draw unselected points
-  for (auto i = 0; i < dataSize; ++i) {
+  auto ids = m_xs.keys();
+  for (auto id : ids) {
     // we do not draw selected or highlighted indexes because we draw them later
-    if (m_selectedPoints.contains(i) || m_highlightedPoint == i) {
+    if (m_selectedIds.contains(id) || m_highlightedId == id) {
       continue;
     }
     painter->beginPath();
-    painter->circle(m_xs.at(i), m_ys.at(i), m_pen.radius);
+    painter->circle(m_xs.value(id), m_ys.value(id), m_pen.radius);
     painter->fill();
     painter->stroke();
   }
 
   // draw selected points
-  if (m_selectedPoints.size() > 0) {
+  if (m_selectedIds.size() > 0) {
     painter->setStrokeStyle(QNanoColor::fromQColor(m_selectedPen.stroke));
     painter->setFillStyle(QNanoColor::fromQColor(m_selectedPen.fill));
     painter->setLineWidth(m_selectedPen.width);
     painter->setLineJoin(m_selectedPen.join);
     painter->setLineCap(m_selectedPen.cap);
 
-    for (auto i : m_selectedPoints) {
+    for (auto i : m_selectedIds) {
       // we don't draw highlighted indexes here
-      if (i == m_highlightedPoint) {
+      if (i == m_highlightedId) {
         continue;
       }
 
       painter->beginPath();
-      painter->circle(m_xs.at(i), m_ys.at(i), m_selectedPen.radius);
+      painter->circle(m_xs.value(i), m_ys.value(i), m_selectedPen.radius);
       painter->fill();
       painter->stroke();
     }
   }
 
   // draw highlighted points
-  if (m_highlightedPoint > -1) {
+  if (m_highlightedId > -1) {
     painter->setStrokeStyle(QNanoColor::fromQColor(m_highlightedPen.stroke));
     painter->setFillStyle(QNanoColor::fromQColor(m_highlightedPen.fill));
     painter->setLineWidth(m_highlightedPen.width);
@@ -86,7 +87,7 @@ void QniteCirclePainter::paint(QNanoPainter *painter) {
     painter->setLineCap(m_highlightedPen.cap);
 
     painter->beginPath();
-    painter->circle(m_xs.at(m_highlightedPoint), m_ys.at(m_highlightedPoint),
+    painter->circle(m_xs.value(m_highlightedId), m_ys.value(m_highlightedId),
                     m_highlightedPen.radius);
     painter->fill();
     painter->stroke();

--- a/src/items/qnitecirclepainter.cpp
+++ b/src/items/qnitecirclepainter.cpp
@@ -47,7 +47,7 @@ void QniteCirclePainter::paint(QNanoPainter *painter) {
   // draw unselected points
   auto ids = m_xs.keys();
   for (auto id : ids) {
-    // we do not draw selected or highlighted indexes because we draw them later
+    // we do not draw selected or highlighted ids because we draw them later
     if (m_selectedIds.contains(id) || m_highlightedId == id) {
       continue;
     }
@@ -65,21 +65,21 @@ void QniteCirclePainter::paint(QNanoPainter *painter) {
     painter->setLineJoin(m_selectedPen.join);
     painter->setLineCap(m_selectedPen.cap);
 
-    for (auto i : m_selectedIds) {
-      // we don't draw highlighted indexes here
-      if (i == m_highlightedId) {
+    for (auto id : m_selectedIds) {
+      // we don't draw highlighted ids here, nor those currently not visible
+      if (id == m_highlightedId || !ids.contains(id)) {
         continue;
       }
 
       painter->beginPath();
-      painter->circle(m_xs.value(i), m_ys.value(i), m_selectedPen.radius);
+      painter->circle(m_xs.value(id), m_ys.value(id), m_selectedPen.radius);
       painter->fill();
       painter->stroke();
     }
   }
 
-  // draw highlighted points
-  if (m_highlightedId > -1) {
+  // draw highlighted point if visible
+  if (m_highlightedId > -1 && ids.contains(m_highlightedId)) {
     painter->setStrokeStyle(QNanoColor::fromQColor(m_highlightedPen.stroke));
     painter->setFillStyle(QNanoColor::fromQColor(m_highlightedPen.fill));
     painter->setLineWidth(m_highlightedPen.width);

--- a/src/items/qnitecirclepainter.h
+++ b/src/items/qnitecirclepainter.h
@@ -19,15 +19,15 @@ private:
   QnitePen::PenData m_highlightedPen;
 
   // xy artist data
-  QList<qreal> m_xs;
-  QList<qreal> m_ys;
+  QMap<int, qreal> m_xs;
+  QMap<int, qreal> m_ys;
 
   // circle data
   qreal m_radius;
   qreal m_selectedRadius;
   qreal m_highlightedRadius;
-  QList<int> m_selectedPoints;
-  int m_highlightedPoint;
+  QList<int> m_selectedIds;
+  int m_highlightedId;
 };
 
 #endif /* QNITECIRCLEPAINTER_H */

--- a/src/items/qniteline.cpp
+++ b/src/items/qniteline.cpp
@@ -23,11 +23,12 @@ bool QniteLine::select(QPoint p) {
   bool accepted = false;
 
   // get the distance from the first point on the path
-  int dataSize = xMapped().size();
-  for (int i = 0; i < dataSize; ++i) {
-    QPoint cp(xMapped().at(i), yMapped().at(i));
-    QPoint d = p - cp;
-    if (d.manhattanLength() < SELECTION_TOLERANCE) {
+  auto ids = m_xMapped.keys();
+  for (auto id : ids) {
+    QPointF cp(m_xMapped.value(id), m_yMapped.value(id));
+    QPointF d = p - cp;
+    auto distance = d.manhattanLength();
+    if (distance < SELECTION_TOLERANCE) {
       m_selected = true;
       accepted = true;
       axes()->setOnTop(this);

--- a/src/items/qnitelinepainter.cpp
+++ b/src/items/qnitelinepainter.cpp
@@ -85,10 +85,11 @@ void QniteLinePainter::paint(QNanoPainter *painter) {
       symbolColor.setAlphaF(1.0);
       painter->setFillStyle(QNanoColor::fromQColor(symbolColor));
     }
-    dataSize = m_mappedXs.size();
-    for (auto i = 0; i < dataSize; ++i) {
+    auto ids = m_mappedXs.keys();
+    for (auto id : ids) {
       painter->beginPath();
-      painter->circle(m_mappedXs.at(i), m_mappedYs.at(i), pen.width * 2.5);
+      painter->circle(m_mappedXs.value(id), m_mappedYs.value(id),
+                      pen.width * 2.5);
       painter->fill();
       painter->stroke();
     }

--- a/src/items/qnitelinepainter.h
+++ b/src/items/qnitelinepainter.h
@@ -21,8 +21,8 @@ private:
   QList<qreal> m_xs;
   QList<qreal> m_ys;
 
-  QList<qreal> m_mappedXs;
-  QList<qreal> m_mappedYs;
+  QMap<int, qreal> m_mappedXs;
+  QMap<int, qreal> m_mappedYs;
 
   // line data
   qreal m_baseline;

--- a/src/items/qnitespline.cpp
+++ b/src/items/qnitespline.cpp
@@ -106,8 +106,8 @@ void QniteSpline::cosineInterpolation() {
   QList<qreal> xs;
   QList<qreal> ys;
 
-  const auto &xv = xMapped();
-  const auto &yv = yMapped();
+  const auto &xv = xMapped().values();
+  const auto &yv = yMapped().values();
 
   int n = xv.size() - 1;
   int res = 2;
@@ -135,8 +135,8 @@ void QniteSpline::cubicInterpolation() {
   QList<qreal> xs;
   QList<qreal> ys;
 
-  auto xv = xMapped();
-  auto yv = yMapped();
+  auto xv = xMapped().values();
+  auto yv = yMapped().values();
 
   auto n = xv.size();
   auto res = 2;

--- a/src/qniteclipper.cpp
+++ b/src/qniteclipper.cpp
@@ -4,27 +4,62 @@ QniteClipper::QniteClipper(QObject *parent) : QObject(parent) {}
 
 QniteClipper::~QniteClipper() {}
 
+void QniteClipper::clip(const QMap<int, qreal> &xValues,
+                        const QMap<int, qreal> &yValues, qreal xLower,
+                        qreal xUpper, qreal yLower, qreal yUpper,
+                        QMap<int, qreal> &outX, QMap<int, qreal> &outY) {
+  // Assume x and y values have same ids
+  auto ids = xValues.keys();
+
+  for (auto id : ids) {
+    auto x = xValues.value(id);
+    auto y = yValues.value(id);
+    if (x >= xLower && x <= xUpper) {
+      if (y >= yLower && y <= yUpper) {
+        outX.insert(id, x);
+        outY.insert(id, y);
+      }
+    }
+  }
+}
+
 void QniteClipper::clip(const QList<qreal> &xValues,
                         const QList<qreal> &yValues, qreal xLower, qreal xUpper,
                         qreal yLower, qreal yUpper, QList<qreal> &outX,
                         QList<qreal> &outY) {
+
   int size = qMin(xValues.size(), yValues.size());
 
-  for (int i = 0; i < size; ++i) {
+  for (int i = 0; i < size; i++) {
     auto x = xValues.at(i);
     auto y = yValues.at(i);
-    if (x >= xLower && x <= xUpper)
+    if (x >= xLower && x <= xUpper) {
       if (y >= yLower && y <= yUpper) {
-        outX.append(x);
-        outY.append(y);
+        outX << x;
+        outY << y;
       }
+    }
+  }
+}
+
+void QniteClipper::clip(const QMap<int, qreal> &values, qreal lower,
+                        qreal upper, QMap<int, qreal> &out) {
+
+  auto it = values.constBegin();
+  while (it != values.constEnd()) {
+    auto v = it.value();
+    if (v >= lower && v <= upper) {
+      out.insert(it.key(), v);
+    }
+    it++;
   }
 }
 
 void QniteClipper::clip(const QList<qreal> &values, qreal lower, qreal upper,
                         QList<qreal> &out) {
-  for (const auto &v : values) {
-    if (v >= lower && v <= upper)
-      out.append(v);
+  for (auto v : values) {
+    if (v >= lower && v <= upper) {
+      out << v;
+    }
   }
 }

--- a/src/qniteclipper.h
+++ b/src/qniteclipper.h
@@ -1,6 +1,7 @@
 #ifndef QNITE_CLIPPER_H
 #define QNITE_CLIPPER_H
 
+#include <QMap>
 #include <QObject>
 
 class QniteClipper : public QObject {
@@ -9,9 +10,18 @@ public:
   explicit QniteClipper(QObject *parent = 0);
   virtual ~QniteClipper();
 
+  virtual void clip(const QMap<int, qreal> &xValues,
+                    const QMap<int, qreal> &yValues, qreal xLower, qreal xUpper,
+                    qreal yLower, qreal yUpper, QMap<int, qreal> &outX,
+                    QMap<int, qreal> &outY);
+
   virtual void clip(const QList<qreal> &xValues, const QList<qreal> &yValues,
                     qreal xLower, qreal xUpper, qreal yLower, qreal yUpper,
                     QList<qreal> &outX, QList<qreal> &outY);
+
+  virtual void clip(const QMap<int, qreal> &values, qreal lower, qreal upper,
+                    QMap<int, qreal> &out);
+
   virtual void clip(const QList<qreal> &values, qreal lower, qreal upper,
                     QList<qreal> &out);
 };

--- a/src/qnitelinearaxis.cpp
+++ b/src/qnitelinearaxis.cpp
@@ -27,10 +27,14 @@ void QniteLinearAxis::processData() {
     clipper.clip(m_ticker->minorTicks(), m_lowerBound, m_upperBound, min);
 
     // map to display
-    m_majorTicks =
-        m_mapper->mapTo(m_lowerBound, m_upperBound, 0, m_size, maj, m_flip);
-    m_minorTicks =
-        m_mapper->mapTo(m_lowerBound, m_upperBound, 0, m_size, min, m_flip);
+    for (auto v : maj) {
+      m_majorTicks << m_mapper->mapTo(m_lowerBound, m_upperBound, 0, m_size, v,
+                                      m_flip);
+    }
+    for (auto v : min) {
+      m_minorTicks << m_mapper->mapTo(m_lowerBound, m_upperBound, 0, m_size, v,
+                                      m_flip);
+    }
 
     for (auto i = 0; i < maj.size(); ++i) {
       m_labels.push_back(QString("%1").arg(maj.at(i)));

--- a/src/qnitemapper.cpp
+++ b/src/qnitemapper.cpp
@@ -13,14 +13,17 @@ QniteMapper::QniteMapper(QObject *parent) : QObject(parent) {}
 
 QniteMapper::~QniteMapper() {}
 
-QList<qreal> QniteMapper::mapTo(qreal sourceLower, qreal sourceUpper,
-                                qreal destLower, qreal destUpper,
-                                const QList<qreal> &values, bool flip) {
-  QList<qreal> out;
-  for (const auto &value : values) {
-    auto v = mapTo(sourceLower, sourceUpper, destLower, destUpper, value, flip);
-    out.append(v);
-  }
+QMap<int, qreal> QniteMapper::mapTo(qreal sourceLower, qreal sourceUpper,
+                                    qreal destLower, qreal destUpper,
+                                    const QMap<int, qreal> &values, bool flip) {
+  QMap<int, qreal> out;
 
+  auto it = values.constBegin();
+  while (it != values.constEnd()) {
+    auto v =
+        mapTo(sourceLower, sourceUpper, destLower, destUpper, it.value(), flip);
+    out.insert(it.key(), v);
+    it++;
+  }
   return out;
 }

--- a/src/qnitemapper.h
+++ b/src/qnitemapper.h
@@ -1,6 +1,7 @@
 #ifndef QNITE_MAPPER_H
 #define QNITE_MAPPER_H
 
+#include <QMap>
 #include <QObject>
 
 class QniteMapper : public QObject {
@@ -9,9 +10,10 @@ public:
   explicit QniteMapper(QObject *parent = 0);
   virtual ~QniteMapper();
 
-  virtual QList<qreal> mapTo(qreal sourceLower, qreal sourceUpper,
-                             qreal destLower, qreal destUpper,
-                             const QList<qreal> &values, bool flip = false);
+  virtual QMap<int, qreal> mapTo(qreal sourceLower, qreal sourceUpper,
+                                 qreal destLower, qreal destUpper,
+                                 const QMap<int, qreal> &values,
+                                 bool flip = false);
 
   virtual qreal mapTo(qreal sourceLower, qreal sourceUpper, qreal destLower,
                       qreal destUpper, qreal values, bool flip = false) = 0;

--- a/src/qnitexyartist.cpp
+++ b/src/qnitexyartist.cpp
@@ -10,11 +10,14 @@ QniteXYArtist::QniteXYArtist(QQuickItem *parent)
 
 QniteXYArtist::~QniteXYArtist() {}
 
-const QList<qreal> &QniteXYArtist::xValues() { return m_xValues; }
+QList<qreal> QniteXYArtist::xValues() { return m_xValues.values(); }
 
 void QniteXYArtist::setXValues(const QList<qreal> &values) {
-  if (m_xValues != values) {
-    m_xValues = values;
+  if (m_xValues.values() != values) {
+    m_xValues.clear();
+    for (int i = 0; i < values.size(); i++) {
+      m_xValues.insert(i, values.at(i));
+    }
     // TODO: transform the values here and cache
     emit xValuesChanged();
     update();
@@ -24,11 +27,14 @@ void QniteXYArtist::setXValues(const QList<qreal> &values) {
   }
 }
 
-const QList<qreal> &QniteXYArtist::yValues() { return m_yValues; }
+QList<qreal> QniteXYArtist::yValues() { return m_yValues.values(); }
 
 void QniteXYArtist::setYValues(const QList<qreal> &values) {
-  if (m_yValues != values) {
-    m_yValues = values;
+  if (m_yValues.values() != values) {
+    m_yValues.clear();
+    for (int i = 0; i < values.size(); i++) {
+      m_yValues.insert(i, values.at(i));
+    }
     // TODO: transform the values here and cache
     emit yValuesChanged();
     update();
@@ -71,13 +77,13 @@ void QniteXYArtist::setClipper(QniteClipper *clipper) {
   }
 }
 
-const QList<qreal> &QniteXYArtist::xMapped() const { return m_xMapped; }
+QMap<int, qreal> QniteXYArtist::xMapped() const { return m_xMapped; }
 
-const QList<qreal> &QniteXYArtist::yMapped() const { return m_yMapped; }
+QMap<int, qreal> QniteXYArtist::yMapped() const { return m_yMapped; }
 
-const QList<qreal> &QniteXYArtist::xProcessed() const { return m_xProcessed; }
+QList<qreal> QniteXYArtist::xProcessed() const { return m_xProcessed; }
 
-const QList<qreal> &QniteXYArtist::yProcessed() const { return m_yProcessed; }
+QList<qreal> QniteXYArtist::yProcessed() const { return m_yProcessed; }
 
 void QniteXYArtist::processData() {
   if (qMin(xValues().size(), yValues().size()) < 1) {
@@ -92,15 +98,15 @@ void QniteXYArtist::processData() {
 
   // TODO: this should be improved. clipping should be done only when bounds
   // changes and tranforsm should always be performed
-  QList<qreal> xClipped;
-  QList<qreal> yClipped;
+  QMap<int, qreal> xClipped;
+  QMap<int, qreal> yClipped;
   // clip non visible data
   if (clipper() != nullptr) {
-    clipper()->clip(xValues(), yValues(), xLower, xUpper, yLower, yUpper,
+    clipper()->clip(m_xValues, m_yValues, xLower, xUpper, yLower, yUpper,
                     xClipped, yClipped);
   } else {
-    xClipped = xValues();
-    yClipped = yValues();
+    xClipped = m_xValues;
+    yClipped = m_yValues;
   }
 
   // map to display
@@ -109,8 +115,8 @@ void QniteXYArtist::processData() {
 
   // TODO: this is ugly and inefficient. move into a pipelino or something
   // similar move to the output area
-  m_xProcessed = m_xMapped;
-  m_yProcessed = m_yMapped;
+  m_xProcessed = m_xMapped.values();
+  m_yProcessed = m_yMapped.values();
 }
 
 void QniteXYArtist::updateAxes() {
@@ -125,8 +131,8 @@ void QniteXYArtist::updateAxes() {
     if (axes->axisY() != nullptr)
       this->setYMapper(axes->axisY()->mapper());
 
-    disconnect(axes, SIGNAL(axisXChanged()), this, 0);
-    disconnect(axes, SIGNAL(axisYChanged()), this, 0);
+    disconnect(axes, SIGNAL(axisXChanged()), this, nullptr);
+    disconnect(axes, SIGNAL(axisYChanged()), this, nullptr);
 
     connect(axes, &QniteAxes::axisXChanged, this,
             [=]() { this->setXMapper(axes->axisX()->mapper()); });

--- a/src/qnitexyartist.h
+++ b/src/qnitexyartist.h
@@ -7,18 +7,18 @@ class QniteClipper;
 class QniteMapper;
 class QniteXYArtist : public QniteArtist {
   Q_OBJECT
-  Q_PROPERTY(
-      QList<qreal> xValues READ xValues WRITE setXValues NOTIFY xValuesChanged)
-  Q_PROPERTY(
-      QList<qreal> yValues READ yValues WRITE setYValues NOTIFY yValuesChanged)
+  // clang-format off
+  Q_PROPERTY(QList<qreal> xValues READ xValues WRITE setXValues NOTIFY xValuesChanged)
+  Q_PROPERTY(QList<qreal> yValues READ yValues WRITE setYValues NOTIFY yValuesChanged)
+  // clang-format on
 
 public:
-  explicit QniteXYArtist(QQuickItem *parent = 0);
-  virtual ~QniteXYArtist();
+  explicit QniteXYArtist(QQuickItem *parent = nullptr);
+  virtual ~QniteXYArtist() Q_DECL_OVERRIDE;
 
-  const QList<qreal> &xValues();
+  QList<qreal> xValues();
   void setXValues(const QList<qreal> &values);
-  const QList<qreal> &yValues();
+  QList<qreal> yValues();
   void setYValues(const QList<qreal> &values);
 
   QniteMapper *xMapper() const;
@@ -28,11 +28,11 @@ public:
   QniteClipper *clipper() const;
   void setClipper(QniteClipper *clipper);
 
-  const QList<qreal> &xMapped() const;
-  const QList<qreal> &yMapped() const;
+  QMap<int, qreal> xMapped() const;
+  QMap<int, qreal> yMapped() const;
 
-  const QList<qreal> &xProcessed() const;
-  const QList<qreal> &yProcessed() const;
+  QList<qreal> xProcessed() const;
+  QList<qreal> yProcessed() const;
 
 public Q_SLOTS:
   virtual void processData() Q_DECL_OVERRIDE;
@@ -44,16 +44,16 @@ Q_SIGNALS:
 protected:
   virtual void updateAxes() Q_DECL_OVERRIDE;
 
-  QList<qreal> m_xMapped;
-  QList<qreal> m_yMapped;
+  QMap<int, qreal> m_xMapped;
+  QMap<int, qreal> m_yMapped;
 
   QList<qreal> m_xProcessed;
   QList<qreal> m_yProcessed;
 
-private:
-  QList<qreal> m_xValues;
-  QList<qreal> m_yValues;
+  QMap<int, qreal> m_xValues;
+  QMap<int, qreal> m_yValues;
 
+private:
   QniteClipper *m_clipper;
   QniteMapper *m_xMapper;
   QniteMapper *m_yMapper;

--- a/src/tools/qnitezoomtool.cpp
+++ b/src/tools/qnitezoomtool.cpp
@@ -67,6 +67,7 @@ void QniteZoomTool::mouseMoveEvent(QMouseEvent *event) {
 
 void QniteZoomTool::mouseReleaseEvent(QMouseEvent *event) {
   if (m_zoomRect.isNull() || event->pos() == m_zoomRect.topLeft()) {
+    m_zoomRect = QRectF{};
     return;
   }
 

--- a/src/tools/qnitezoomtool.cpp
+++ b/src/tools/qnitezoomtool.cpp
@@ -74,27 +74,30 @@ void QniteZoomTool::mouseReleaseEvent(QMouseEvent *event) {
   auto yMin = qMin(m_zoomRect.top(), m_zoomRect.bottom());
   auto yMax = qMax(m_zoomRect.top(), m_zoomRect.bottom());
 
-  QList<qreal> yValues{{yMin, yMax}};
-
   auto yAxis = axes()->axisY();
-  auto yMapped =
+  auto yMappedMin =
       yAxis->mapper()->mapTo(0, axes()->height(), yAxis->lowerBound(),
-                             yAxis->upperBound(), yValues, yAxis->flip());
+                             yAxis->upperBound(), yMin, yAxis->flip());
+  auto yMappedMax =
+      yAxis->mapper()->mapTo(0, axes()->height(), yAxis->lowerBound(),
+                             yAxis->upperBound(), yMax, yAxis->flip());
 
   auto xMin = qMin(m_zoomRect.left(), m_zoomRect.right());
   auto xMax = qMax(m_zoomRect.left(), m_zoomRect.right());
 
-  QList<qreal> xValues{{xMin, xMax}};
-
   auto xAxis = axes()->axisX();
-  auto xMapped =
+  auto xMappedMin =
       xAxis->mapper()->mapTo(0, axes()->width(), xAxis->lowerBound(),
-                             xAxis->upperBound(), xValues, xAxis->flip());
+                             xAxis->upperBound(), xMin, xAxis->flip());
 
-  yAxis->setLowerBound(qMin(yMapped.first(), yMapped.last()));
-  yAxis->setUpperBound(qMax(yMapped.first(), yMapped.last()));
-  xAxis->setLowerBound(qMin(xMapped.first(), xMapped.last()));
-  xAxis->setUpperBound(qMax(xMapped.first(), xMapped.last()));
+  auto xMappedMax =
+      xAxis->mapper()->mapTo(0, axes()->width(), xAxis->lowerBound(),
+                             xAxis->upperBound(), xMax, xAxis->flip());
+
+  yAxis->setLowerBound(qMin(yMappedMin, yMappedMax));
+  yAxis->setUpperBound(qMax(yMappedMin, yMappedMax));
+  xAxis->setLowerBound(qMin(xMappedMin, xMappedMax));
+  xAxis->setUpperBound(qMax(xMappedMin, xMappedMax));
 
   m_zoomRect = QRectF{};
 
@@ -103,8 +106,8 @@ void QniteZoomTool::mouseReleaseEvent(QMouseEvent *event) {
 
   // Disables tool if calculated bounds are smaller than the minimum zoom size
   auto minSize = minimumZoomSize();
-  auto axisYSize = qAbs(yMapped.first() - yMapped.last());
-  auto axisXSize = qAbs(xMapped.first() - xMapped.last());
+  auto axisYSize = qAbs(yMappedMin - yMappedMax);
+  auto axisXSize = qAbs(xMappedMin - xMappedMax);
 
   if (axisXSize <= minSize.width() || axisYSize <= minSize.height()) {
     setEnabled(false);

--- a/tests/tst_qnitelinearmapper/tst_qnitelinearmapper.cpp
+++ b/tests/tst_qnitelinearmapper/tst_qnitelinearmapper.cpp
@@ -59,9 +59,9 @@ void TestQniteLinearMapper::testMapTo() {
 }
 
 void TestQniteLinearMapper::testMapToMulti() {
-  auto r = mapper.mapTo(0.0, 10.0, 0.0, 100.0, {1.5, 3.5});
-  QCOMPARE(r.at(0), 15.0);
-  QCOMPARE(r.at(1), 35.0);
+  auto r = mapper.mapTo(0.0, 10.0, 0.0, 100.0, {{0, 1.5}, {3, 3.5}});
+  QCOMPARE(r.value(0), 15.0);
+  QCOMPARE(r.value(3), 35.0);
 }
 
 QTEST_MAIN(TestQniteLinearMapper)


### PR DESCRIPTION
This rework permits to use both the zoom and selection tool on the same plot.