### PR TITLE
Allow to select stepped line painting

### DIFF
--- a/examples/line/main.qml
+++ b/examples/line/main.qml
@@ -1,3 +1,4 @@
+import QtQuick 2.0
 import QtQuick.Controls 2.3
 import QtQuick.Layouts 1.3
 
@@ -11,9 +12,17 @@ ApplicationWindow {
     ColumnLayout {
         anchors.fill: parent
 
-        CheckBox {
-            id: _drawSymbols
-            text: "Draw Symbols"
+        RowLayout
+        {
+            CheckBox {
+                id: _drawSymbols
+                text: "Draw Symbols"
+            }
+
+            CheckBox {
+                id: _drawStepped
+                text: "Draw Stepped line"
+            }
         }
 
         Figure {
@@ -26,6 +35,7 @@ ApplicationWindow {
                 yValues: [0, 0.3, 0.6, 0.3, 0.4, 0.6]
 
                 drawSymbols: _drawSymbols.checked
+                drawStepped: _drawStepped.checked
             }
 
             Layout.fillWidth: true

--- a/src/items/qniteline.cpp
+++ b/src/items/qniteline.cpp
@@ -11,7 +11,8 @@ Q_LOGGING_CATEGORY(qniteline, "qnite.line")
 constexpr auto SELECTION_TOLERANCE = 50;
 
 QniteLine::QniteLine(QQuickItem *parent)
-    : QniteXYArtist(parent), m_selected{false}, m_drawSymbols{true}, m_drawStepped{false} {}
+    : QniteXYArtist(parent), m_selected{false}, m_drawSymbols{true},
+      m_drawStepped{false} {}
 
 /*!
   Temporary implementation of the selection logic for lines.

--- a/src/items/qniteline.cpp
+++ b/src/items/qniteline.cpp
@@ -11,7 +11,7 @@ Q_LOGGING_CATEGORY(qniteline, "qnite.line")
 constexpr auto SELECTION_TOLERANCE = 50;
 
 QniteLine::QniteLine(QQuickItem *parent)
-    : QniteXYArtist(parent), m_selected{false}, m_drawSymbols{true} {}
+    : QniteXYArtist(parent), m_selected{false}, m_drawSymbols{true}, m_drawStepped{false} {}
 
 /*!
   Temporary implementation of the selection logic for lines.

--- a/src/items/qniteline.cpp
+++ b/src/items/qniteline.cpp
@@ -62,6 +62,14 @@ void QniteLine::setDrawSymbols(bool drawSymbols) {
   }
 }
 
+void QniteLine::setDrawStepped(bool drawStepped) {
+  if (this->m_drawStepped != drawStepped) {
+    this->m_drawStepped = drawStepped;
+    emit drawSteppedChanged();
+    update();
+  }
+}
+
 QNanoQuickItemPainter *QniteLine::createItemPainter() const {
   qCDebug(qniteline) << "creating item painter";
   return new QniteLinePainter();

--- a/src/items/qniteline.h
+++ b/src/items/qniteline.h
@@ -9,6 +9,8 @@ class QniteLine : public QniteXYArtist {
   Q_OBJECT
   Q_PROPERTY(bool drawSymbols READ drawSymbols WRITE setDrawSymbols NOTIFY
                  drawSymbolsChanged)
+  Q_PROPERTY(bool drawStepped READ drawStepped WRITE setDrawStepped NOTIFY
+                 drawSteppedChanged)
 
 public:
   explicit QniteLine(QQuickItem *parent = 0);
@@ -18,12 +20,15 @@ public:
   void clearSelection() Q_DECL_OVERRIDE;
 
   bool drawSymbols() const { return m_drawSymbols; }
+  bool drawStepped() const { return m_drawStepped; }
   void setDrawSymbols(bool drawSymbols);
+  void setDrawStepped(bool drawStepped);
 
   QNanoQuickItemPainter *createItemPainter() const Q_DECL_OVERRIDE;
 
 signals:
   void drawSymbolsChanged();
+  void drawSteppedChanged();
 
 protected:
   virtual bool isSelected() const Q_DECL_OVERRIDE { return m_selected; }
@@ -31,6 +36,7 @@ protected:
 private:
   bool m_selected;
   bool m_drawSymbols;
+  bool m_drawStepped;
 };
 
 #endif // QNITE_LINE_H

--- a/src/items/qnitelinepainter.cpp
+++ b/src/items/qnitelinepainter.cpp
@@ -9,7 +9,8 @@
 Q_LOGGING_CATEGORY(qnitelinepainter, "qnite.line.painter")
 
 QniteLinePainter::QniteLinePainter()
-    : QNanoQuickItemPainter{}, m_selected{false}, m_drawSymbols{false}, m_drawStepped{false} {}
+    : QNanoQuickItemPainter{}, m_selected{false}, m_drawSymbols{false},
+      m_drawStepped{false} {}
 
 void QniteLinePainter::synchronize(QNanoQuickItem *item) {
   qCDebug(qnitelinepainter) << "synchronizing qniteline";
@@ -66,11 +67,10 @@ void QniteLinePainter::paint(QNanoPainter *painter) {
     painter->moveTo(m_xs.at(0), m_baseline);
     painter->lineTo(m_xs.at(0), m_ys.at(0));
     for (auto i = 1; i < dataSize; ++i) {
-        if (m_drawStepped)
-        {
-          painter->lineTo(m_xs.at(i), m_ys.at(i - 1));
-        }
-        painter->lineTo(m_xs.at(i), m_ys.at(i));
+      if (m_drawStepped) {
+        painter->lineTo(m_xs.at(i), m_ys.at(i - 1));
+      }
+      painter->lineTo(m_xs.at(i), m_ys.at(i));
     }
     painter->lineTo(m_xs.at(dataSize - 1), m_baseline);
     painter->fill();
@@ -79,11 +79,10 @@ void QniteLinePainter::paint(QNanoPainter *painter) {
   painter->beginPath();
   painter->moveTo(m_xs.at(0), m_ys.at(0));
   for (auto i = 1; i < dataSize; ++i) {
-      if (m_drawStepped)
-      {
-        painter->lineTo(m_xs.at(i), m_ys.at(i - 1));
-      }
-      painter->lineTo(m_xs.at(i), m_ys.at(i));
+    if (m_drawStepped) {
+      painter->lineTo(m_xs.at(i), m_ys.at(i - 1));
+    }
+    painter->lineTo(m_xs.at(i), m_ys.at(i));
   }
   painter->stroke();
 

--- a/src/items/qnitelinepainter.cpp
+++ b/src/items/qnitelinepainter.cpp
@@ -9,7 +9,7 @@
 Q_LOGGING_CATEGORY(qnitelinepainter, "qnite.line.painter")
 
 QniteLinePainter::QniteLinePainter()
-    : QNanoQuickItemPainter{}, m_selected{false}, m_drawSymbols{false} {}
+    : QNanoQuickItemPainter{}, m_selected{false}, m_drawSymbols{false}, m_drawStepped{false} {}
 
 void QniteLinePainter::synchronize(QNanoQuickItem *item) {
   qCDebug(qnitelinepainter) << "synchronizing qniteline";
@@ -39,6 +39,8 @@ void QniteLinePainter::synchronize(QNanoQuickItem *item) {
     m_baseline = lineItem->axes()->axisY()->position();
 
     m_drawSymbols = lineItem->drawSymbols();
+
+    m_drawStepped = lineItem->drawStepped();
   }
 }
 
@@ -62,8 +64,13 @@ void QniteLinePainter::paint(QNanoPainter *painter) {
   if (pen.fill.isValid()) {
     painter->beginPath();
     painter->moveTo(m_xs.at(0), m_baseline);
-    for (auto i = 0; i < dataSize; ++i) {
-      painter->lineTo(m_xs.at(i), m_ys.at(i));
+    painter->lineTo(m_xs.at(0), m_ys.at(0));
+    for (auto i = 1; i < dataSize; ++i) {
+        if (m_drawStepped)
+        {
+          painter->lineTo(m_xs.at(i), m_ys.at(i - 1));
+        }
+        painter->lineTo(m_xs.at(i), m_ys.at(i));
     }
     painter->lineTo(m_xs.at(dataSize - 1), m_baseline);
     painter->fill();
@@ -72,7 +79,11 @@ void QniteLinePainter::paint(QNanoPainter *painter) {
   painter->beginPath();
   painter->moveTo(m_xs.at(0), m_ys.at(0));
   for (auto i = 1; i < dataSize; ++i) {
-    painter->lineTo(m_xs.at(i), m_ys.at(i));
+      if (m_drawStepped)
+      {
+        painter->lineTo(m_xs.at(i), m_ys.at(i - 1));
+      }
+      painter->lineTo(m_xs.at(i), m_ys.at(i));
   }
   painter->stroke();
 

--- a/src/items/qnitelinepainter.h
+++ b/src/items/qnitelinepainter.h
@@ -29,6 +29,8 @@ private:
 
   // draw symbols flag
   bool m_drawSymbols;
+  // draw stepped flag
+  bool m_drawStepped;
 };
 
 #endif /* QNITELINEPAINTER_H */


### PR DESCRIPTION
A stepped line graph (also called step chart) is a chart similar to a line graph, but with the line forming a series of steps between data points. A stepped line chart can be useful when you want to show the changes that occur at irregular intervals.

This PR introduces a simple bool property to allow stepped plotting. The line chart example is also updated to include a checkbox to test the new property.