### PR TITLE
Fix in point selection: iterate all plot points to select the nearest one

### DIFF
--- a/src/items/qnitecircle.cpp
+++ b/src/items/qnitecircle.cpp
@@ -77,7 +77,6 @@ bool QniteCircle::select(const QPoint p) {
       nearestId = id;
       nearestIndex = index;
       nearestDistance = distance;
-      break;
     }
     index++;
   }

--- a/src/items/qnitecircle.cpp
+++ b/src/items/qnitecircle.cpp
@@ -62,7 +62,6 @@ bool QniteCircle::select(const QPoint p) {
   // these variables are needed to keep
   // track of the nearest point during the search
   auto nearestId = -1;
-  auto nearestIndex = -1;
   // we only evaluate points whose distance is below a
   // predefined tolerance
   qreal nearestDistance = SELECTION_TOLERANCE;
@@ -75,7 +74,6 @@ bool QniteCircle::select(const QPoint p) {
     auto distance = d.manhattanLength();
     if (distance < nearestDistance) {
       nearestId = id;
-      nearestIndex = index;
       nearestDistance = distance;
     }
     index++;
@@ -84,6 +82,7 @@ bool QniteCircle::select(const QPoint p) {
   // add the index to the selected points pool
   if (nearestId >= 0) {
     m_selectedIds.insert(nearestId);
+    auto nearestIndex = m_xValues.keys().indexOf(nearestId);
     m_selectedIndexes.insert(nearestIndex);
     emit selectedChanged();
     update();


### PR DESCRIPTION
The current selection code appears to iterate on all points in order, then select the FIRST one that is at distance lower than SELECTION_TOLERANCE.
However, when the plot has many points, this method cannot guarantee to pick the one nearest to the clicked point.

This one liner ensures all the points are evaluated and the nearest point is always selected. The computational impact seems negligible, we tested the selection in a 6000+ points plot and the performance was good enough.